### PR TITLE
Name for the resource is 'underscorized'.

### DIFF
--- a/lib/api_client.rb
+++ b/lib/api_client.rb
@@ -21,6 +21,7 @@ module ApiClient
   module Resource
     autoload :Base,          "api_client/resource/base"
     autoload :Scope,         "api_client/resource/scope"
+    autoload :NameResolver,  "api_client/resource/name_resolver"
   end
 
   module Connection

--- a/lib/api_client/resource/base.rb
+++ b/lib/api_client/resource/base.rb
@@ -14,7 +14,7 @@ module ApiClient
 
         def inherited(subclass)
           super
-          small_name = subclass.name.split('::').last.downcase
+          small_name = NameResolver.resolve(subclass.name)
           subclass.namespace small_name
           subclass.prefix    self.prefix
           subclass.always do

--- a/lib/api_client/resource/name_resolver.rb
+++ b/lib/api_client/resource/name_resolver.rb
@@ -1,0 +1,37 @@
+module ApiClient
+  module Resource
+    class NameResolver
+      def self.resolve(ruby_path)
+        new(ruby_path).resolve
+      end
+
+      attr_reader :name
+
+      def initialize(name)
+        @name = name
+      end
+
+      def resolve
+        select_last_item
+        underscorize
+        lowercase
+        name
+      end
+
+      private
+      def select_last_item
+        @name = @name.split('::').last
+      end
+
+      #Inspired by ActiveSupport::Inflector#underscore
+      def underscorize
+        @name.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
+        @name.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+      end
+
+      def lowercase
+        @name.downcase!
+      end
+    end
+  end
+end

--- a/spec/api_client/resource/name_spec.rb
+++ b/spec/api_client/resource/name_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe ApiClient::Resource::NameResolver do
+  describe '.resolve' do
+    subject { described_class }
+
+    it 'changes My::Namespace::MyResouce to my_resource' do
+      subject.resolve('My::Namespace::MyResource').should == 'my_resource'
+    end
+
+    it 'changes Resource to resource' do
+      subject.resolve('Resource').should == 'resource'
+    end
+
+    it 'changes My::Resource to resoure' do
+      subject.resolve('My::Resource').should == 'resource'
+    end
+  end
+end


### PR DESCRIPTION
It seems that more often than not if the api has resources that are more than one word then they are referred to with underscore instead of one word. For example user_account as opposed to useraccount.
