### PR TITLE
Strict attribute reader

### DIFF
--- a/lib/api_client/base.rb
+++ b/lib/api_client/base.rb
@@ -16,7 +16,7 @@ module ApiClient
 
       delegate :fetch, :get, :put, :post, :delete, :headers, :endpoint, :options, :adapter, :params, :raw, :to => :scope
 
-      dsl_accessor :format, :namespace, :strict_attr_reader
+      dsl_accessor :format, :namespace
 
       def subkey_class
         Hashie::Mash
@@ -61,7 +61,7 @@ module ApiClient
       if respond_to?(method_name)
         super
       else
-        if self.class.strict_attr_reader
+        if respond_to?(:strict_attr_reader?) && self.strict_attr_reader?
           fetch(method_name)
         else
           super

--- a/spec/api_client/base_spec.rb
+++ b/spec/api_client/base_spec.rb
@@ -11,11 +11,16 @@ describe ApiClient::Base do
   end
 
   class StrictApi < ApiClient::Base
-    self.strict_attr_reader true
-
     def accessor_of_x
       self.x
     end
+
+    def strict_attr_reader?
+      true
+    end
+  end
+
+  class StrictDescendant < StrictApi
   end
 
   describe "#inspect" do
@@ -67,6 +72,11 @@ describe ApiClient::Base do
     it "calling method which asks for missing attribute fails" do
       api = StrictApi.new
       lambda { api.accessor_of_x }.should raise_error(KeyError)
+    end
+
+    it "passes strict api configuration to subclasses" do
+      api = StrictDescendant.new
+      lambda { api.missing }.should raise_error(KeyError)
     end
   end
 end


### PR DESCRIPTION
This pull request allows users to set strict attribute reading which raises `KeyError` for attributes which don't exist (the same as `Hash#fetch` and actually implemented using it).
# Why?

Errors which occur because you thought the key was in the response you fetched but it is never there (different representation).

Example fail: 

```
if api_object.email # not every object has email but some do
   # handle stuff if email is there but it was never there so this doesn't work
end
```
# Usage

Errors which are caused by this should probably not be rescued because you don't want to have Exception-driven flow.

Instead of this:

```
begin
  object.custom_fields
rescue KeyError
  ojbect.custom_field_values
end
```

You probably want to:

```
if object.custom_fields?
  object.custom_fields
else
  # blabla
end
```
# Testing

Tested on sandbox mailman and seems to work. Also this doesn't affect anything until you enable it in fs-api probably. In mailman for testing purposes we did:

```
class ApiClient::Base
  def strict_attr_reader?
    true
  end
end
```

We can do it gradually on a per-class basis, eventually we probably want to have it on all fs-api classes?
