### PR TITLE
Compatibility fix of strict_attr_reader for hashie 2.1.0

### DIFF
--- a/lib/api_client/base.rb
+++ b/lib/api_client/base.rb
@@ -58,15 +58,17 @@ module ApiClient
 
     private
     def method_missing(method_name, *args, &blk)
-      if respond_to?(method_name)
+      if respond_to?(method_name) || has_special_ending?(method_name)
         super
+      elsif respond_to?(:strict_attr_reader?) && self.strict_attr_reader?
+        fetch(method_name)
       else
-        if respond_to?(:strict_attr_reader?) && self.strict_attr_reader?
-          fetch(method_name)
-        else
-          super
-        end
+        super
       end
+    end
+
+    def has_special_ending?(name)
+      name.to_s =~ /[?=]$/
     end
   end
 end

--- a/spec/api_client/base_spec.rb
+++ b/spec/api_client/base_spec.rb
@@ -60,8 +60,14 @@ describe ApiClient::Base do
 
     it "doesn't fail if the key was set after object was created" do
       api = StrictApi.new
-      api.not_missing = 1
+      lambda { api.not_missing = 1 }.should_not raise_error
       api.not_missing.should == 1
+    end
+
+    it "doesn't fail for predicate methods if key is not set" do
+      api = StrictApi.new
+      lambda { api.missing? }.should_not raise_error
+      api.missing?.should be_false
     end
 
     it "allows to call methods" do


### PR DESCRIPTION
Hashie 2.1.0 changes the behaviour of respond_to? in a strange way which in effect makes it impossible to set non-existing attributes after an object is created. This PR allows all calls to methods ending with '=' or '?' even if strict_attr_reader is enabled.
