### PR TITLE
add build of java platform gem

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -8,13 +8,16 @@ jobs:
   build:
     name: Build + Publish
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["2.6.x", "jruby"]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
-        version: 2.6.x
+        version: ${{ matrix.ruby-version }}
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -13,9 +13,9 @@ jobs:
         ruby-version: ["2.6.x", "jruby"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: zendesk/checkout@v2
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: zendesk/setup-ruby@v1
       with:
         version: ${{ matrix.ruby-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,9 @@ jobs:
         - jruby-9.2.11.1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: zendesk/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: zendesk/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Install dependencies

--- a/api_client.gemspec
+++ b/api_client.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "api_client"
   s.required_ruby_version = ">= 2.2.0"
+  
+  s.platform = "java" if RUBY_PLATFORM == "java"
  
   # Declare runtime dependencies here:
   def s.add_runtime_dependencies(method)


### PR DESCRIPTION
to support `jruby` from rubygems, we need to push two gems - one ruby platform and one java platform as they each have different dependencies (that are computed on the gem build time)