### PR TITLE
Support for higher than 1.0.0 version of faraday gem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - 2.2.10
         - 2.3.8
         - 2.4.6
         - 2.5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.27
+
+* Add support for faraday gem version >= 1.0.0 and < 2.0.0
+
 # 0.5.26
 
 * Add support for HTTP status code: 412 Precondition Failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.27
 
 * Add support for faraday gem version >= 1.0.0 and < 2.0.0
+* Drop support for Ruby < 2.3
 
 # 0.5.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.5.27
+# 0.6.0
 
 * Add support for faraday gem version >= 1.0.0 and < 2.0.0
 * Drop support for Ruby < 2.3

--- a/api_client.gemspec
+++ b/api_client.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license     = "Apache License Version 2.0"
 
   s.rubyforge_project = "api_client"
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.3.8"
 
   s.platform = "java" if RUBY_PLATFORM == "java"
 

--- a/api_client.gemspec
+++ b/api_client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     end
 
     send method, 'hashie', [">= 2.0.5"]
-    send method, 'faraday', [">= 0.8.1", "< 1.0.0"]
+    send method, 'faraday', [">= 0.8.1", "< 2.0.0"]
     send method, 'multi_json', [">= 1.6.1"]
   end
 

--- a/lib/api_client/connection/basic.rb
+++ b/lib/api_client/connection/basic.rb
@@ -88,7 +88,7 @@ module ApiClient
         response = @handler.send(method, path, data, headers)
         request = { :method => method, :path => path, :data => data}
         handle_response(request, response)
-      rescue Faraday::Error::ConnectionFailed => e
+      rescue Faraday::ConnectionFailed => e
         raise ApiClient::Errors::ConnectionFailed.new(e.message, request, response)
       end
 

--- a/lib/api_client/version.rb
+++ b/lib/api_client/version.rb
@@ -1,3 +1,3 @@
 module ApiClient
-  VERSION = '0.5.27'
+  VERSION = '0.6.0'
 end

--- a/lib/api_client/version.rb
+++ b/lib/api_client/version.rb
@@ -1,3 +1,3 @@
 module ApiClient
-  VERSION = '0.5.26'
+  VERSION = '0.5.27'
 end

--- a/spec/api_client/connection/basic_spec.rb
+++ b/spec/api_client/connection/basic_spec.rb
@@ -9,17 +9,18 @@ describe ApiClient::Connection::Basic do
 
   it "adds basic middlewares to faraday" do
     instance = ApiClient::Connection::Basic.new("http://google.com")
-    instance.handler.builder.handlers.collect(&:name).should == ["Faraday::Request::UrlEncoded", "Faraday::Adapter::NetHttp"]
+    instance.handler.builder.adapter.name.should == "Faraday::Adapter::NetHttp"
+    instance.handler.builder.handlers.collect(&:name).should == ["Faraday::Request::UrlEncoded"]
   end
 
   it "adds the logger middlewares to faraday if ApiClient.logger is available" do
     logger = double
     ApiClient.stub(:logger).and_return(logger)
     instance = ApiClient::Connection::Basic.new("http://google.com")
+    instance.handler.builder.adapter.name.should == "Faraday::Adapter::NetHttp"
     instance.handler.builder.handlers.collect(&:name).should == [
       "ApiClient::Connection::Middlewares::Request::Logger",
-      "Faraday::Request::UrlEncoded",
-      "Faraday::Adapter::NetHttp"
+      "Faraday::Request::UrlEncoded"
     ]
 
   end

--- a/spec/api_client/connection/basic_spec.rb
+++ b/spec/api_client/connection/basic_spec.rb
@@ -9,11 +9,7 @@ describe ApiClient::Connection::Basic do
 
   it "uses correct adapter" do
     instance = ApiClient::Connection::Basic.new("http://google.com")
-    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3")
-      expect(instance.handler.builder.handlers.collect(&:name)).to include("Faraday::Adapter::NetHttp")
-    else
-      expect(instance.handler.builder.adapter.name).to eq("Faraday::Adapter::NetHttp")
-    end
+    expect(instance.handler.builder.adapter.name).to eq("Faraday::Adapter::NetHttp")
   end
 
   it "adds basic middlewares to faraday" do

--- a/spec/api_client/connection/oauth_spec.rb
+++ b/spec/api_client/connection/oauth_spec.rb
@@ -4,11 +4,7 @@ describe ApiClient::Connection::Oauth do
 
   it "uses correct adapter" do
     instance = ApiClient::Connection::Oauth.new("http://google.com")
-    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3")
-      expect(instance.handler.builder.handlers.collect(&:name)).to include("Faraday::Adapter::NetHttp")
-    else
-      expect(instance.handler.builder.adapter.name).to eq("Faraday::Adapter::NetHttp")
-    end
+    expect(instance.handler.builder.adapter.name).to eq("Faraday::Adapter::NetHttp")
   end
 
   it "adds basic middlewares to faraday" do

--- a/spec/api_client/connection/oauth_spec.rb
+++ b/spec/api_client/connection/oauth_spec.rb
@@ -4,10 +4,10 @@ describe ApiClient::Connection::Oauth do
 
   it "adds basic middlewares to faraday" do
     instance = ApiClient::Connection::Oauth.new("http://google.com")
+    instance.handler.builder.adapter.name.should == "Faraday::Adapter::NetHttp"
     instance.handler.builder.handlers.collect(&:name).should == [
       "ApiClient::Connection::Middlewares::Request::OAuth",
-      "Faraday::Request::UrlEncoded",
-      "Faraday::Adapter::NetHttp"
+      "Faraday::Request::UrlEncoded"
     ]
   end
 
@@ -15,11 +15,11 @@ describe ApiClient::Connection::Oauth do
     logger = double
     ApiClient.stub(:logger).and_return(logger)
     instance = ApiClient::Connection::Oauth.new("http://google.com")
+    instance.handler.builder.adapter.name.should == "Faraday::Adapter::NetHttp"
     instance.handler.builder.handlers.collect(&:name).should == [
       "ApiClient::Connection::Middlewares::Request::Logger",
       "ApiClient::Connection::Middlewares::Request::OAuth",
-      "Faraday::Request::UrlEncoded",
-      "Faraday::Adapter::NetHttp"
+      "Faraday::Request::UrlEncoded"
     ]
 
   end

--- a/spec/api_client/connection/oauth_spec.rb
+++ b/spec/api_client/connection/oauth_spec.rb
@@ -2,26 +2,26 @@ require "spec_helper"
 
 describe ApiClient::Connection::Oauth do
 
+  it "uses correct adapter" do
+    instance = ApiClient::Connection::Oauth.new("http://google.com")
+    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3")
+      expect(instance.handler.builder.handlers.collect(&:name)).to include("Faraday::Adapter::NetHttp")
+    else
+      expect(instance.handler.builder.adapter.name).to eq("Faraday::Adapter::NetHttp")
+    end
+  end
+
   it "adds basic middlewares to faraday" do
     instance = ApiClient::Connection::Oauth.new("http://google.com")
-    instance.handler.builder.adapter.name.should == "Faraday::Adapter::NetHttp"
-    instance.handler.builder.handlers.collect(&:name).should == [
-      "ApiClient::Connection::Middlewares::Request::OAuth",
-      "Faraday::Request::UrlEncoded"
-    ]
+    expect(instance.handler.builder.handlers.collect(&:name))
+      .to include("ApiClient::Connection::Middlewares::Request::OAuth", "Faraday::Request::UrlEncoded")
   end
 
   it "adds the logger middlewares to faraday if ApiClient.logger is available" do
     logger = double
     ApiClient.stub(:logger).and_return(logger)
     instance = ApiClient::Connection::Oauth.new("http://google.com")
-    instance.handler.builder.adapter.name.should == "Faraday::Adapter::NetHttp"
-    instance.handler.builder.handlers.collect(&:name).should == [
-      "ApiClient::Connection::Middlewares::Request::Logger",
-      "ApiClient::Connection::Middlewares::Request::OAuth",
-      "Faraday::Request::UrlEncoded"
-    ]
-
+    expect(instance.handler.builder.handlers.collect(&:name))
+      .to include("ApiClient::Connection::Middlewares::Request::Logger", "ApiClient::Connection::Middlewares::Request::OAuth", "Faraday::Request::UrlEncoded")
   end
-
 end


### PR DESCRIPTION
- add support for faraday > 1.0.0 - we need it because `sell-crm` needs to upgrade `gibbon` gem which has security vulnerability. The fixed `gibon` version depends on faraday > 1.0.0 so we need to allow for higher version.
- drop support for Ruby < 2.3 - we checked the [list of ruby versions](https://docs.google.com/spreadsheets/d/191m37K8M-8UE7efPop4QxU_8o9EJfP5eRblBG42YQVo/edit#gid=1899856398) in our services and it looks that there are no services on Ruby 2.2.10 that uses `api_client` so we can safely drop support for Ruby 2.2.