### PR TITLE
Run tests on Ruby 3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,10 @@ jobs:
         - 2.7.6
         - 3.0.4
         - 3.1.2
+        - 3.2.0
 
     steps:
-    - uses: zendesk/checkout@v2
+    - uses: zendesk/checkout@v3
     - name: Set up Ruby
       uses: zendesk/setup-ruby@v1
       with:


### PR DESCRIPTION
Adds Ruby 3.2.0 to the test matrix.
