### PR TITLE
update Rspec and examples to support Ruby 3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
         - 2.3.8
         - 2.4.6
         - 2.5.5
         - 2.6.3
-        - 2.7.6
-        - 3.0.4
-        - 3.1.2
+        - 2.7.7
+        - 3.0.5
+        - 3.1.3
         - 3.2.0
 
     steps:

--- a/api_client.gemspec
+++ b/api_client.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   end
 
   # Declare development dependencies here:
-  s.add_development_dependency 'rspec', '2.14.1'
+  s.add_development_dependency 'rspec', '< 4'
 
   if s.respond_to? :specification_version then
     s.specification_version = 3

--- a/examples/flickr.rb
+++ b/examples/flickr.rb
@@ -1,6 +1,6 @@
 require "rubygems"
 require "bundler/setup"
-require "./examples/config" if File.exists?('examples/config.rb')
+require "./examples/config" if File.exist?('examples/config.rb')
 require "api_client"
 
 module Flickr

--- a/examples/github.rb
+++ b/examples/github.rb
@@ -1,6 +1,6 @@
 require "rubygems"
 require "bundler/setup"
-require "./examples/config" if File.exists?('examples/config.rb')
+require "./examples/config" if File.exist?('examples/config.rb')
 require "api_client"
 require "time"
 

--- a/examples/highrise.rb
+++ b/examples/highrise.rb
@@ -1,6 +1,6 @@
 require "rubygems"
 require "bundler/setup"
-require "./examples/config" if File.exists?('examples/config.rb')
+require "./examples/config" if File.exist?('examples/config.rb')
 require "api_client"
 require "multi_xml"
 

--- a/examples/twitter_oauth.rb
+++ b/examples/twitter_oauth.rb
@@ -1,6 +1,6 @@
 require "rubygems"
 require "bundler/setup"
-require "./examples/config" if File.exists?('examples/config.rb')
+require "./examples/config" if File.exist?('examples/config.rb')
 require "api_client"
 
 module TwitterOauth

--- a/spec/api_client/base/connection_hook_spec.rb
+++ b/spec/api_client/base/connection_hook_spec.rb
@@ -9,8 +9,8 @@ describe ApiClient::Base do
       class ConnectionHookTest < ApiClient::Base
         connection &ConnectionHookTestProc
       end
-      ConnectionHookTest.connection_hooks.size.should == 1
-      ConnectionHookTest.connection_hooks.should == [ConnectionHookTestProc]
+      expect(ConnectionHookTest.connection_hooks.size).to eq(1)
+      expect(ConnectionHookTest.connection_hooks).to eq([ConnectionHookTestProc])
     end
 
   end

--- a/spec/api_client/base_spec.rb
+++ b/spec/api_client/base_spec.rb
@@ -80,7 +80,7 @@ describe ApiClient::Base do
     it "doesn't fail for predicate methods if key is not set" do
       api = StrictApi.new
       lambda { api.missing? }.should_not raise_error
-      api.missing?.should be_false
+      expect(api.missing?).to be false
     end
 
     it "allows to call methods" do

--- a/spec/api_client/resource/base_spec.rb
+++ b/spec/api_client/resource/base_spec.rb
@@ -64,14 +64,14 @@ describe ApiClient::Resource::Base do
     describe "#remote_update" do
 
       it "delegates the update to the class" do
-        ApiClient::Resource::Base.should_receive(:update).with(42, "name" => "Mike")
+        ApiClient::Resource::Base.should_receive(:update).with(42, { "name" => "Mike" })
         @instance.remote_update
       end
 
       it "retains the original scope" do
         ApiClient::Resource::Base.stub(:update)
         @instance.original_scope = double
-        @instance.original_scope.should_receive(:update).with(42, "name" => "Mike")
+        @instance.original_scope.should_receive(:update).with(42, { "name" => "Mike" })
         @instance.remote_update
       end
 
@@ -80,13 +80,13 @@ describe ApiClient::Resource::Base do
     describe "#remote_create" do
 
       it "delegates the create to the class" do
-        ApiClient::Resource::Base.should_receive(:create).with("name" => "Mike")
+        ApiClient::Resource::Base.should_receive(:create).with({ "name" => "Mike" })
         @instance.remote_create
       end
 
       it "retains the original scope" do
         @instance.original_scope = double
-        @instance.original_scope.should_receive(:create).with("name" => "Mike")
+        @instance.original_scope.should_receive(:create).with({ "name" => "Mike" })
         @instance.remote_create
       end
 


### PR DESCRIPTION
`File.exists?` has been deprecated in Ruby 3.2 (it’s been marked as deprecated [since 2.2](https://ruby-doc.org/core-2.2.0/File.html#method-c-exists-3F), and `exist?` is available in all supported Ruby versions). Fixed examples to use `exist?` and updated Rspec to 3.x (Rspec 2.x also uses `exists?`).